### PR TITLE
Switch npm publishing to Trusted Publishing (OIDC) with provenance

### DIFF
--- a/.changeset/switch-to-trusted-publishing.md
+++ b/.changeset/switch-to-trusted-publishing.md
@@ -1,0 +1,5 @@
+---
+"rn-barcode-renderer": patch
+---
+
+Publish to npm via GitHub Actions Trusted Publishing (OIDC) with provenance attestations. No runtime code changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     name: Release
@@ -15,12 +20,15 @@ jobs:
     if: github.repository == 'igortrnko/rn-barcode-renderer'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 20
-        uses: actions/setup-node@v3
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
+
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@latest
 
       - name: Install Dependencies
         run: yarn
@@ -40,4 +48,3 @@ jobs:
           title: Next release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "release": "yarn changeset publish"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.5.0",
-    "@changesets/cli": "^2.27.1",
+    "@changesets/changelog-github": "^0.7.0",
+    "@changesets/cli": "^2.31.0",
     "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,16 +611,16 @@
   dependencies:
     "@changesets/types" "^6.1.0"
 
-"@changesets/changelog-github@^0.5.0":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@changesets/changelog-github/-/changelog-github-0.5.2.tgz#6225ffcea0698af3ef7403780c8bbc2e93ffa5a0"
-  integrity sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==
+"@changesets/changelog-github@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@changesets/changelog-github/-/changelog-github-0.7.0.tgz#c359fe8cbb711a2247873c3623e7e47654a5ef16"
+  integrity sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==
   dependencies:
-    "@changesets/get-github-info" "^0.7.0"
+    "@changesets/get-github-info" "^0.8.0"
     "@changesets/types" "^6.1.0"
     dotenv "^8.1.0"
 
-"@changesets/cli@^2.27.1":
+"@changesets/cli@^2.31.0":
   version "2.31.0"
   resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.31.0.tgz#7576348cb96ec7ec1d103f5a830cdf6d1ee60426"
   integrity sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==
@@ -683,10 +683,10 @@
     picocolors "^1.1.0"
     semver "^7.5.3"
 
-"@changesets/get-github-info@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@changesets/get-github-info/-/get-github-info-0.7.0.tgz#d0a55e894343ee719a01901151dba86dfebb2bef"
-  integrity sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==
+"@changesets/get-github-info@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@changesets/get-github-info/-/get-github-info-0.8.0.tgz#6921dcf3735239b9fbc413e5a111d81f9a65f66f"
+  integrity sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==
   dependencies:
     dataloader "^1.4.0"
     node-fetch "^2.5.0"


### PR DESCRIPTION
- Add workflow permissions: contents/pull-requests write + id-token: write
- Update npm to latest before publish (OIDC requires npm >= 11.5.1)
- Drop NPM_TOKEN from the publish step
- Bump actions/checkout and setup-node to v4, Node 20 -> 22
- Update @changesets/cli and @changesets/changelog-github to latest